### PR TITLE
Small Fixes

### DIFF
--- a/MainLoop.cpp
+++ b/MainLoop.cpp
@@ -2,6 +2,7 @@
 
 #include <condition_variable>
 #include <future>
+#include <queue>
 
 namespace {
 constexpr auto sleepTime { 250 };

--- a/Worker.cpp
+++ b/Worker.cpp
@@ -1,9 +1,12 @@
 #include "Worker.h"
 
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <iostream>
+#include <mutex>
 #include <queue>
+#include <sstream>
 #include <thread>
 
 namespace {

--- a/Worker.cpp
+++ b/Worker.cpp
@@ -132,7 +132,9 @@ void Worker::addTask(const std::function<void()> &task) noexcept
             d_ptr->tasks.push(task);
         }
         d_ptr->waitCondition.notify_one();
-    } catch (const std::exception & /*e*/) {
+    } catch (const std::exception &e) {
+        std::cerr << __PRETTY_FUNCTION__ << ' ' << d_ptr->workerName
+                  << " - Exception in addTask: " << e.what() << '\n';
     }
 }
 
@@ -145,7 +147,9 @@ void Worker::addTask(std::function<void()> &&task) noexcept
         }
 
         d_ptr->waitCondition.notify_one();
-    } catch (const std::exception & /*e*/) {
+    } catch (const std::exception &e) {
+        std::cerr << __PRETTY_FUNCTION__ << ' ' << d_ptr->workerName
+                  << " - Exception in addTask: " << e.what() << '\n';
     }
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,7 @@
 #include <csignal>
 #include <iostream>
 #include <random>
+#include <sstream>
 #include <thread>
 
 #include <ncurses.h>


### PR DESCRIPTION
 Ponto mais importante: 
A função `waitCondition.wait(lock, [this] { return !isRunning() || !tasks.empty(); });` é usada para suspender a execução de uma thread até que a condição dentro da lambda seja satisfeita.

1. **`waitCondition.wait(lock, ...)`**: suspende a execução da thread que o chamou até que a condição especificada seja verdadeira, também libera o `lock` enquanto a thread está esperando e o readquire quando a thread é acordada.

2. **`lock`**:  garante que o acesso aos recursos compartilhados seja seguro entre múltiplas threads. O `lock` é passado para o método `wait` para que ele possa ser liberado enquanto a thread está esperando, permitindo que outras threads modifiquem os recursos compartilhados.

3. **Lambda `[this] { return !isRunning() || !tasks.empty(); }`**: esta lambda define a condição para que a thread seja acordada. A lambda captura o ponteiro `this`  para acessar os membros da classe. A condição especificada é que a thread deve continuar esperando até que `isRunning()` retorne `false` ou que a fila de `tasks` não esteja vazia.

4. **`isRunning()`**: verifica se a thread ainda está em execução.  Se `isRunning()` retornar `false`, significa que a thread deve parar de esperar porque o processo de execução foi sinalizado para terminar.

5. **`tasks.empty()`**: se a fila não estiver vazia, significa que há trabalho a ser feito, e a thread deve ser acordada para processar as tarefas.

